### PR TITLE
Preventing blindView from delegate to be overwritten

### DIFF
--- a/BKPasscodeView/BKPasscodeLockScreenManager.m
+++ b/BKPasscodeView/BKPasscodeLockScreenManager.m
@@ -57,7 +57,7 @@ static BKPasscodeLockScreenManager *_sharedManager;
         blindView = [self.delegate lockScreenManagerBlindView:self];
     }
     
-    if (nil == self.blindView) {
+    if (nil == blindView) {
         blindView = [[UIView alloc] init];
         blindView.backgroundColor = [UIColor whiteColor];
     }


### PR DESCRIPTION
self.blindView is not assigned yet so it will always be nil at this point so the blindView from delegate (if existent) will get overwritten